### PR TITLE
Remove warnings that pop up in newer versions of Elixir.

### DIFF
--- a/lib/mix/tasks/compile.asn1.ex
+++ b/lib/mix/tasks/compile.asn1.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Compile.Asn1 do
 #    mappings     = Enum.zip(source_paths, dest_paths)
     options      = project[:asn1_options] || []
 
-    build_dest
+    build_dest()
 
     targets = extract_targets(source_paths, dest_paths, opts[:force])
 
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Compile.Asn1 do
   @doc """
   Returns ASN.1 manifests.
   """
-  def manifests, do: [manifest]
+  def manifests, do: [manifest()]
   defp manifest, do: Path.join(Mix.Project.manifest_path, @manifest)
 
   @doc """
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.Compile.Asn1 do
   def clean do
     modules = read_manifest(manifest())
     Enum.each(modules, fn mod -> Enum.each(module_files(Path.dirname(mod),Path.basename(mod)), &File.rm/1) end)
-    File.rm manifest
+    File.rm manifest()
     if File.ls(Path.dirname(List.first(modules)||[])) == {:ok, []} do
       File.rmdir(Path.dirname(List.first(modules)))
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,7 @@ defmodule Asn1ex.Mixfile do
   def project do
     [app: :asn1ex,
      version: "0.0.1",
-     elixir: ">= 0.15.1 and ~> 1.0.2",
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
* For some time now, with newer versions of Elixir, bare names used as functions (arity 0) are discouraged and issue warnings if not terminated with ().
* Also removed (elixir: ">= 0.15.1 and ~> 1.0.2") from mix.exs.