### PR TITLE
Fails to build asn1 modules due to wrong list type

### DIFF
--- a/lib/mix/tasks/compile.asn1.ex
+++ b/lib/mix/tasks/compile.asn1.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Compile.Asn1 do
 #    mappings     = Enum.zip(source_paths, dest_paths)
     options      = project[:asn1_options] || []
 
-    build_dest
+    build_dest()
 
     targets = extract_targets(source_paths, dest_paths, opts[:force])
 
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Compile.Asn1 do
   @doc """
   Returns ASN.1 manifests.
   """
-  def manifests, do: [manifest]
+  def manifests, do: [manifest()]
   defp manifest, do: Path.join(Mix.Project.manifest_path, @manifest)
 
   @doc """
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.Compile.Asn1 do
   def clean do
     modules = read_manifest(manifest())
     Enum.each(modules, fn mod -> Enum.each(module_files(Path.dirname(mod),Path.basename(mod)), &File.rm/1) end)
-    File.rm manifest
+    File.rm manifest()
     if File.ls(Path.dirname(List.first(modules)||[])) == {:ok, []} do
       File.rmdir(Path.dirname(List.first(modules)))
     end

--- a/lib/mix/tasks/compile.asn1.ex
+++ b/lib/mix/tasks/compile.asn1.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Compile.Asn1 do
     compile(manifest(), targets, fn
       input, output ->
         options = options ++ [:noobj, outdir: Erlang.to_erl_file(Path.dirname(output))]
-        { :asn1ct.compile(Erlang.to_erl_file(List.first(input)), options),
+        { :asn1ct.compile(Erlang.to_erl_file(input), options),
           # String.to_atom Path.basename(input, "set.asn1")}
           Path.basename(output)}
     end)

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Asn1ex.Mixfile do
     [app: :asn1ex,
      version: "0.0.1",
      elixir: ">= 0.15.1 and ~> 1.4.2",
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Asn1ex.Mixfile do
   def project do
     [app: :asn1ex,
      version: "0.0.1",
-     elixir: ">= 0.15.1 and ~> 1.0.2",
+     elixir: ">= 0.15.1 and ~> 1.4.2",
      deps: deps]
   end
 


### PR DESCRIPTION
** (FunctionClauseError) no function clause matching in List.first/1
    (elixir) lib/list.ex:219: List.first("asn1/DNS-ASN1.asn1")
    lib/mix/tasks/compile.asn1.ex:54: anonymous fn/3 in Mix.Tasks.Compile.Asn1.run/1
    lib/mix/tasks/compile.asn1.ex:156: anonymous fn/3 in Mix.Tasks.Compile.Asn1.compile/3
    (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/mix/tasks/compile.asn1.ex:155: Mix.Tasks.Compile.Asn1.compile/3
    (mix) lib/mix/task.ex:294: Mix.Task.run_task/3
    (elixir) lib/enum.ex:1229: Enum."-map/2-lists^map/1-0-"/2
    (mix) lib/mix/tasks/compile.all.ex:19: anonymous fn/1 in Mix.Tasks.Compile.All.run/1

And updated for compatibility with latest erlang/elixir/mix