### PR TITLE
Updated configuration load and added examples of config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ Other configuration options:
 - `:asn1_options` - compilation options that apply to ASN.1's compiler. There
   are many other available options here:
   http://erlang.org/doc/man/asn1ct.html#compile-2.
+
+Config Examples:
+- `config :asn1ex, :asn1_options, [:maps, :per]`
+- `config :asn1ex, :erlc_paths, ["src"]`
+- `config :asn1ex, :asn1_paths, ["asn1"]`

--- a/lib/mix/tasks/compile.asn1.ex
+++ b/lib/mix/tasks/compile.asn1.ex
@@ -37,11 +37,10 @@ defmodule Mix.Tasks.Compile.Asn1 do
   def run(args) do
     {opts, _, _} = OptionParser.parse(args, switches: [force: :boolean])
 
-    project      = Mix.Project.config
-    source_paths = project[:asn1_paths] || ["asn1"]
-    dest_paths    = project[:erlc_paths]
+    source_paths = Application.get_env(:asn1ex, :asn1_paths) || ["asn1"]
+    dest_paths    = Application.get_env(:asn1ex, :erlc_paths) || ["src"]
 #    mappings     = Enum.zip(source_paths, dest_paths)
-    options      = project[:asn1_options] || []
+    options      = Application.get_env(:asn1ex, :asn1_options) || []
 
     build_dest()
 

--- a/lib/mix/tasks/compile.asn1.ex
+++ b/lib/mix/tasks/compile.asn1.ex
@@ -37,10 +37,10 @@ defmodule Mix.Tasks.Compile.Asn1 do
   def run(args) do
     {opts, _, _} = OptionParser.parse(args, switches: [force: :boolean])
 
-    source_paths = Application.get_env(:asn1ex, :asn1_paths) || ["asn1"]
-    dest_paths    = Application.get_env(:asn1ex, :erlc_paths) || ["src"]
+    source_paths = Application.get_env(:asn1ex, :asn1_paths)
+    dest_paths    = Application.get_env(:asn1ex, :erlc_paths)
 #    mappings     = Enum.zip(source_paths, dest_paths)
-    options      = Application.get_env(:asn1ex, :asn1_options) || []
+    options      = Application.get_env(:asn1ex, :asn1_options)
 
     build_dest()
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,9 @@ defmodule Asn1ex.Mixfile do
   end
 
   def application do
-    []
+    [
+      env: [asn1_paths: ["asn1"], erlc_paths: ["src"], asn1_options: []]
+    ]
   end
 
   defp deps do


### PR DESCRIPTION
The old way to load configuration is not working anymore (otp 22, elixir 1.9), so I updated it to a more reliable API.